### PR TITLE
Remove some line-breaks to refresh build cache

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -211,7 +211,6 @@ jobs:
 
   msys:
     runs-on: windows-2019
-
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +222,6 @@ jobs:
           - mingw: "MINGW64"
             name: "MSYS2 MinGW 64-bit"
             package: "mingw-w64-x86_64"
-
     defaults:
       run:
         shell: bash.exe --login -eo pipefail "{0}"

--- a/setup.py
+++ b/setup.py
@@ -729,7 +729,7 @@ class pil_build_ext(build_ext):
             defs.append(("HAVE_LIBTIFF", None))
             # FIXME the following define should be detected automatically
             #       based on system libtiff, see #4237
-            if PLATFORM_MINGW:
+            if sys.platform == "win32":
                 defs.append(("USE_WIN32_FILEIO", None))
         if feature.xcb:
             libs.append(feature.xcb)

--- a/winbuild/tiff.opt
+++ b/winbuild/tiff.opt
@@ -124,7 +124,7 @@ OPTFLAGS =	/Ox /MD /EHsc /W3 /D_CRT_SECURE_NO_DEPRECATE
 # instead of Windows specific system calls. See notes on top of tif_unix.c
 # module for details.
 #
-USE_WIN_CRT_LIB = 1
+#USE_WIN_CRT_LIB = 1
 
 # Compiler specific options. You may probably want to adjust compilation
 # parameters in CFLAGS variable. Refer to your compiler documentation


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/pull/5243.

A purely cosmetic change that resets the build cache.